### PR TITLE
msm8974-common: Fix USB ethernet support

### DIFF
--- a/rootdir/etc/init.qcom-common.rc
+++ b/rootdir/etc/init.qcom-common.rc
@@ -503,6 +503,16 @@ service iprenew_p2p /system/bin/dhcpcd -n
     disabled
     oneshot
 
+service dhcpcd_eth0 /system/bin/dhcpcd -aABDKL
+    class late_start
+    disabled
+    oneshot
+
+service iprenew_eth0 /system/bin/dhcpcd -n
+    class late_start
+    disabled
+    oneshot
+
 service dhcpcd_bnep0 /system/bin/dhcpcd -BKLG
     disabled
     oneshot


### PR DESCRIPTION
The code and drivers are there, but there's no service entry in
init.rc for DHCP. Add one.

JIRA: CYAN-6571

Change-Id: Ice50aec839954c89bb85307bbcf90a0ff565f07c
