### PR TITLE
dexpreopt: Only use boot dexpropt

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -151,8 +151,8 @@ EXTENDED_FONT_FOOTPRINT := true
 # Enable dexpreopt to speed boot time
 ifeq ($(HOST_OS),linux)
   ifeq ($(call match-word-in-list,$(TARGET_BUILD_VARIANT),user),true)
-    ifeq ($(WITH_DEXPREOPT),)
-      WITH_DEXPREOPT := true
+    ifeq ($(WITH_DEXPREOPT_BOOT_IMG_ONLY),)
+      WITH_DEXPREOPT_BOOT_IMG_ONLY := true
     endif
   endif
 endif


### PR DESCRIPTION
System space is limited on user builds. Only perform boot dexpreopt
instead of full.

Change-Id: I05537c02d159ca96ce0f063c8df09dc932c6026c
Ticket: CYNGNOS-758
